### PR TITLE
Fix error in browserify build

### DIFF
--- a/xhr-blob.js
+++ b/xhr-blob.js
@@ -3,14 +3,6 @@
 // found in the LICENSE file.
 
 
-// Support was added in iOS7.
-var xhr = new XMLHttpRequest();
-xhr.open('GET', '', true);
-xhr.responseType = 'blob';
-if (xhr.responseType == 'blob') {
-    return;
-}
-
 function proxyMethod(methodName) {
     return function() {
         this._proxy[methodName].apply(this._proxy, arguments);
@@ -103,12 +95,19 @@ function chromeXHR() {
         }
     });
 }
-/* Proxy methods */
-['open','setRequestHeader','send','abort','getResponseHeader','getAllResponseHeaders','overrideMimeType', 'addEventListener', 'removeEventListener'].forEach(function(elem) {
-    chromeXHR.prototype[elem] = proxyMethod(elem);
-});
-chromeXHR.prototype.addEventListener = function(eventName, handler) {
-  this._proxy.addEventListener(eventName, proxyProgressEventHandler(this, eventName.toLowerCase(), handler));
-}
 
-exports.XMLHttpRequest = chromeXHR;
+// Support was added in iOS7.
+var xhr = new XMLHttpRequest();
+xhr.open('GET', '', true);
+xhr.responseType = 'blob';
+if (xhr.responseType != 'blob') {
+    /* Proxy methods */
+    ['open','setRequestHeader','send','abort','getResponseHeader','getAllResponseHeaders','overrideMimeType', 'addEventListener', 'removeEventListener'].forEach(function(elem) {
+        chromeXHR.prototype[elem] = proxyMethod(elem);
+    });
+    chromeXHR.prototype.addEventListener = function(eventName, handler) {
+      this._proxy.addEventListener(eventName, proxyProgressEventHandler(this, eventName.toLowerCase(), handler));
+    }
+    
+    exports.XMLHttpRequest = chromeXHR;
+}


### PR DESCRIPTION
This fixes the following error when trying to build an application with the `--corsify` flag.

```
SyntaxError: 'return' outside of function (11:4) (while aliasify was processing /Users/pwnall/workspace/html5-app-container/cordova/plugins/cordova-plugin-xhr-blob-polyfill/xhr-blob.js) while parsing file: /Users/pwnall/workspace/html5-app-container/cordova/plugins/cordova-plugin-xhr-blob-polyfill/xhr-blob.js
```